### PR TITLE
Improve typography and fix carousel navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,7 @@ ia-para-todos/
 ├── .env.local
 ├── index.html
 ├── package.json
-└── README.md
-```
+└── README.md```
+## Acessibilidade e UDL
+
+Esta aplicação segue boas práticas de acessibilidade e o Universal Design for Learning. Consulte o documento [docs/ACCESSIBILITY_GUIDE.md](docs/ACCESSIBILITY_GUIDE.md) para mais detalhes e recomendações.

--- a/components/AnimatedLogo.tsx
+++ b/components/AnimatedLogo.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 // --- Reusable SVG Logo Component (Animated Version for Navbar) ---
 const AnimatedLogo = ({ className }: { className?: string }) => (
   <svg className={className} viewBox="0 0 2014 2014" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <title>Logótipo IA para Todos</title>
     <defs>
       <linearGradient id="paint0_animated" x1="211.02" y1="1344.54" x2="1912.2" y2="1339.6" gradientUnits="userSpaceOnUse">
         <stop stopColor="#5EE8D1"/>
@@ -23,5 +24,4 @@ const AnimatedLogo = ({ className }: { className?: string }) => (
     <path d="M1278.21 374.933C1272.53 373.8 1272.59 363.7 1278.28 362.637C1340.98 350.928 1469.63 320.157 1533.32 256.475C1596.05 193.745 1626.85 67.9704 1638.95 4.30654C1640.04 -1.43879 1650.67 -1.4341 1651.76 4.31214C1663.8 67.975 1694.49 193.737 1757.17 256.475C1819.87 319.228 1945.62 349.991 2009.4 362.085C2015.15 363.176 2015.15 373.834 2009.4 374.919C1945.61 386.958 1819.88 417.611 1757.17 480.314C1693.5 543.981 1662.88 672.622 1651.23 735.419C1650.17 741.116 1640.05 741.188 1638.91 735.506C1626.19 671.877 1593.72 540.676 1533.32 480.314C1472.95 419.984 1341.74 387.603 1278.21 374.933Z" fill="url(#paint1_animated)"/>
   </svg>
 );
-
 export default AnimatedLogo;

--- a/components/StaticLogo.tsx
+++ b/components/StaticLogo.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 // --- Reusable SVG Logo Component (Static Version) ---
 const StaticLogo = ({ className }: { className?: string }) => (
   <svg className={className} viewBox="0 0 2014 2014" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <title>Logótipo IA para Todos</title>
     <defs>
       <linearGradient id="paint0_static" x1="211.02" y1="1344.54" x2="1912.2" y2="1339.6" gradientUnits="userSpaceOnUse">
         <stop stopColor="#5EE8D1"/>
@@ -21,5 +22,4 @@ const StaticLogo = ({ className }: { className?: string }) => (
     <path d="M1278.21 374.933C1272.53 373.8 1272.59 363.7 1278.28 362.637C1340.98 350.928 1469.63 320.157 1533.32 256.475C1596.05 193.745 1626.85 67.9704 1638.95 4.30654C1640.04 -1.43879 1650.67 -1.4341 1651.76 4.31214C1663.8 67.975 1694.49 193.737 1757.17 256.475C1819.87 319.228 1945.62 349.991 2009.4 362.085C2015.15 363.176 2015.15 373.834 2009.4 374.919C1945.61 386.958 1819.88 417.611 1757.17 480.314C1693.5 543.981 1662.88 672.622 1651.23 735.419C1650.17 741.116 1640.05 741.188 1638.91 735.506C1626.19 671.877 1593.72 540.676 1533.32 480.314C1472.95 419.984 1341.74 387.603 1278.21 374.933Z" fill="url(#paint1_static)"/>
   </svg>
 );
-
 export default StaticLogo;

--- a/components/learning/manifesto/SuggestionForm.tsx
+++ b/components/learning/manifesto/SuggestionForm.tsx
@@ -107,6 +107,7 @@ const SuggestionForm = ({ onSubmitSuggestion, prefilledText, onSubmissionSuccess
                     value={suggestion}
                     onChange={(e) => setSuggestion(e.target.value)}
                     placeholder="Escreva aqui a sua sugestão para um novo princípio..."
+                    aria-label="Sugestão"
                     className="w-full h-32 p-3 border-2 border-pcd-border rounded-lg focus:border-pcd-accent focus:ring-1 focus:ring-pcd-accent transition"
                 />
                 <button

--- a/components/learning/prompt-factory-v2/GamificationNotificationV2.tsx
+++ b/components/learning/prompt-factory-v2/GamificationNotificationV2.tsx
@@ -12,7 +12,7 @@ type GamificationNotificationV2Props = {
 
 const GamificationNotificationV2 = ({ message, onClose }: GamificationNotificationV2Props) => {
   return (
-    <div className="fade-in-down w-full bg-pcd-accent-light border-2 border-pcd-accent/30 rounded-xl shadow-md p-4 flex items-center justify-between z-10">
+    <div className="fade-in-down w-full bg-pcd-accent-light border-2 border-pcd-accent/30 rounded-xl shadow-md p-4 flex items-center justify-between z-10" role="status">
       <div className="flex items-center mr-4">
         <RemixIcon name="sparkling-2-line" className="text-2xl text-pcd-accent mr-3 flex-shrink-0" />
         <p className="text-pcd-accent font-medium text-sm md:text-base">{message}</p>

--- a/components/learning/prompt-factory/GamificationNotification.tsx
+++ b/components/learning/prompt-factory/GamificationNotification.tsx
@@ -12,7 +12,7 @@ type GamificationNotificationProps = {
 
 const GamificationNotification = ({ message, onClose }: GamificationNotificationProps) => {
   return (
-    <div className="fade-in-down w-full bg-pcd-accent-light border-2 border-pcd-accent/30 rounded-xl shadow-md p-4 flex items-center justify-between z-10">
+    <div className="fade-in-down w-full bg-pcd-accent-light border-2 border-pcd-accent/30 rounded-xl shadow-md p-4 flex items-center justify-between z-10" role="status">
       <div className="flex items-center mr-4">
         <RemixIcon name="sparkling-2-line" className="text-2xl text-pcd-accent mr-3 flex-shrink-0" />
         <p className="text-pcd-accent font-medium text-sm md:text-base">{message}</p>

--- a/components/learning/prompt-factory/MedalPopup.tsx
+++ b/components/learning/prompt-factory/MedalPopup.tsx
@@ -13,7 +13,7 @@ type MedalPopupProps = {
 const MedalPopup = ({ message, onClose }: MedalPopupProps) => {
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="fade-in-down bg-white p-6 rounded-2xl shadow-xl text-center max-w-sm mx-auto">
+      <div className="fade-in-down bg-white p-6 rounded-2xl shadow-xl text-center max-w-sm mx-auto" role="status">
         <RemixIcon name="award-fill" className="text-4xl text-yellow-600 mb-3 inline-block" />
         <p className="text-lg font-semibold text-pcd-text-dark mb-4">{message}</p>
         <a

--- a/components/showcase/EmailCaptureBanner.tsx
+++ b/components/showcase/EmailCaptureBanner.tsx
@@ -19,6 +19,7 @@ const EmailCaptureBanner = () => {
                         <input
                             type="email"
                             placeholder="Your email"
+                            aria-label="Email"
                             className="flex-grow w-full px-4 py-2 text-gray-700 bg-pcd-card-bg border border-gray-300 rounded-l-md focus:ring-pcd-accent focus:border-pcd-accent focus:outline-none text-base"
                         />
                         <button className="px-6 py-2 bg-pcd-accent text-white font-semibold rounded-r-md hover:bg-opacity-90 transition-colors border border-pcd-accent -ml-px">
@@ -38,5 +39,4 @@ const EmailCaptureBanner = () => {
         </div>
     );
 };
-
 export default EmailCaptureBanner;

--- a/components/showcase/ListingCard.tsx
+++ b/components/showcase/ListingCard.tsx
@@ -15,9 +15,9 @@ const images = [
 ];
 
 const ListingCard = () => {
-  const slides = images.map((image) => (
+  const slides = images.map((image, idx) => (
     <div key={image} className="w-full h-56">
-        <img src={image} className="w-full h-full object-cover" alt="Propriedade para alugar" />
+        <img src={image} className="w-full h-full object-cover" alt={`Fotografia ${idx + 1} de uma propriedade para arrendamento`} />
     </div>
   ));
 

--- a/components/ui/Carousel.tsx
+++ b/components/ui/Carousel.tsx
@@ -45,14 +45,14 @@ const Carousel = ({ children, withIndicators = false }: CarouselProps) => {
                 <>
                     <button
                         onClick={prev}
-                        className="absolute top-1/2 left-0 transform -translate-y-1/2 bg-white/80 hover:bg-white rounded-full p-2 shadow-lg z-10 -ml-4 focus:outline-none focus:ring-2 focus:ring-pcd-accent"
+                        className="absolute top-1/2 left-0 transform -translate-y-1/2 bg-white/80 hover:bg-white rounded-full p-2 shadow-lg z-10 ml-5 focus:outline-none focus:ring-2 focus:ring-pcd-accent"
                         aria-label="Previous slide"
                     >
                         <RemixIcon name="arrow-left-s-line" className="h-6 w-6 text-gray-700" />
                     </button>
                     <button
                         onClick={next}
-                        className="absolute top-1/2 right-0 transform -translate-y-1/2 bg-white/80 hover:bg-white rounded-full p-2 shadow-lg z-10 -mr-4 focus:outline-none focus:ring-2 focus:ring-pcd-accent"
+                        className="absolute top-1/2 right-0 transform -translate-y-1/2 bg-white/80 hover:bg-white rounded-full p-2 shadow-lg z-10 mr-5 focus:outline-none focus:ring-2 focus:ring-pcd-accent"
                         aria-label="Next slide"
                     >
                         <RemixIcon name="arrow-right-s-line" className="h-6 w-6 text-gray-700" />
@@ -75,5 +75,4 @@ const Carousel = ({ children, withIndicators = false }: CarouselProps) => {
         </div>
     );
 };
-
 export default Carousel;

--- a/docs/ACCESSIBILITY_GUIDE.md
+++ b/docs/ACCESSIBILITY_GUIDE.md
@@ -1,0 +1,27 @@
+# Guia de Acessibilidade
+
+Este guia apresenta boas práticas para garantir que a aplicação "IA para Todos" é acessível a um vasto leque de utilizadores. A abordagem segue os princípios de Acessibilidade Web (WCAG) e do Universal Design for Learning (UDL).
+
+## 1. Critérios implementados
+
+- **Tipografia ampliada:** tamanhos de letra e espaçamento de linhas aumentados para melhorar a legibilidade.
+- **Cores com contraste adequado:** utilização de esquemas de cor com contraste suficiente para garantir que o texto é legível em todas as condições.
+- **Estrutura semântica clara:** os componentes React usam elementos HTML semânticos sempre que possível.
+- **Navegação por teclado:** a interface permite percorrer todos os elementos interativos através do teclado.
+
+## 2. Alinhamento com o UDL
+
+O Universal Design for Learning defende a existência de múltiplas formas de representação, expressão e envolvimento. Algumas boas práticas seguidas são:
+
+- Proporcionar conteúdos em diferentes formatos (texto, vídeo e elementos interativos).
+- Garantir que as imagens e elementos multimédia possuem descrições alternativas.
+- Permitir que o utilizador ajuste preferências, como o tamanho do texto e o contraste das cores.
+
+## 3. Sugestões adicionais
+
+- Validar a aplicação com ferramentas automáticas de acessibilidade (ex.: Lighthouse ou axe).
+- Fornecer opções de controlo do áudio e legendas para conteúdos multimédia.
+- Assegurar que os componentes dinâmicos são anunciados corretamente pelos leitores de ecrã.
+- Realizar testes com utilizadores que possuam necessidades diversas para recolher feedback.
+
+Este documento deverá ser atualizado à medida que forem acrescentadas novas funcionalidades ou que existam novas recomendações de acessibilidade.

--- a/index.css
+++ b/index.css
@@ -18,9 +18,16 @@
   --pcd-pink-light: #FDF2F8;
   --pcd-orange-light: #FFF7ED;
 
+  /* Typography */
+  --font-scale: 1;
+
   /* Theming Accent Colors */
   --pcd-accent-color: var(--pcd-blue);
   --pcd-accent-light-color: var(--pcd-blue-light);
+}
+
+html {
+  font-size: calc(100% * var(--font-scale));
 }
 
 .theme-purple {
@@ -48,6 +55,8 @@
 body {
   font-family: 'Inter', sans-serif;
   scroll-behavior: smooth;
+  font-size: 1.125rem;
+  line-height: 1.6;
   background-color: var(--pcd-page-bg);
 }
 .animated-section {
@@ -205,23 +214,24 @@ section > .container {
     color: var(--pcd-text-dark);
     margin-bottom: 1rem;
 }
-.markdown-content h1 { 
+.markdown-content h1 {
+    font-size: 1.75rem;
+    line-height: 2.25rem;
+    margin-top: 1.5rem;
+}
+.markdown-content h2 {
     font-size: 1.5rem;
     line-height: 2rem;
-    margin-top: 1.5rem; 
-}
-.markdown-content h2 { 
-    font-size: 1.25rem;
-    line-height: 1.75rem;
     margin-top: 1.25rem;
 }
-.markdown-content h3 { 
-    font-size: 1.125rem;
-    line-height: 1.75rem;
+.markdown-content h3 {
+    font-size: 1.25rem;
+    line-height: 1.875rem;
     margin-top: 1rem;
 }
-.markdown-content p { 
-    margin-bottom: 1rem; 
+.markdown-content p {
+    margin-bottom: 1rem;
+    line-height: 1.6;
 }
 .markdown-content ul,
 .markdown-content ol { 
@@ -235,8 +245,9 @@ section > .container {
 .markdown-content ol { 
     list-style-type: decimal; 
 }
-.markdown-content li { 
-    margin-bottom: 0.5rem; 
+.markdown-content li {
+    margin-bottom: 0.5rem;
+    line-height: 1.6;
 }
 .markdown-content strong { 
     font-weight: 600; 

--- a/index.tsx
+++ b/index.tsx
@@ -6,11 +6,13 @@ import React, { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './components/App';
 import './index.css';
+import { appConfig } from './src/config/appConfig';
 
 
 // --- Mount Application to the DOM ---
 const rootElement = document.getElementById('root');
 if (rootElement) {
+    document.documentElement.style.setProperty('--font-scale', String(appConfig.fontScale));
     const root = ReactDOM.createRoot(rootElement);
     root.render(
       <StrictMode>

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -24,6 +24,12 @@ interface AppConfig {
     useStudioNav: boolean;
 
     /**
+     * Global typography scale (1-10)
+     * Adjusts the root font size for accessibility testing.
+     */
+    fontScale: number;
+
+    /**
      * Page-specific Theming
      * Assigns a color theme to each sub-page. The theme class will be applied
      * to the root element of the page.
@@ -55,6 +61,7 @@ interface AppConfig {
 export const appConfig: AppConfig = {
     // --- GENERAL SETTINGS ---
     useStudioNav: false, // <-- SET TO false FOR PRODUCTION
+    fontScale: 5,
 
     // --- PAGE THEMES ---
     pageThemes: {
@@ -77,5 +84,4 @@ export const appConfig: AppConfig = {
         enableManifestoCoCreation: true,
         useGamificationSidebar: true,
         enableComponentLibrary: true,
-    }
-};
+    }};


### PR DESCRIPTION
## Summary
- document accessibility policies in the README and a new guide
- enlarge base text size and heading spacing for better readability
- include line-height for paragraphs and lists
- adjust carousel navigation buttons so arrows remain visible
- add aria labels and roles for better accessibility
- include <title> elements in main SVG logos
- improve alt text in listing carousel
- add configuration option to scale all typography
- set default font scale to 5

## Testing
- `npm run build`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d749388bc832aaae46bd0fa004348