### PR TITLE
Set fontScale default to 5

### DIFF
--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -61,7 +61,7 @@ interface AppConfig {
 export const appConfig: AppConfig = {
     // --- GENERAL SETTINGS ---
     useStudioNav: false, // <-- SET TO false FOR PRODUCTION
-    fontScale: 1,
+    fontScale: 5,
 
     // --- PAGE THEMES ---
     pageThemes: {
@@ -83,5 +83,4 @@ export const appConfig: AppConfig = {
         showGamificationSection: true,
         enableManifestoCoCreation: true,
         useGamificationSidebar: true,
-        enableComponentLibrary: true,
-    }};
+        enableComponentLibrary: true,    }};


### PR DESCRIPTION
## Summary
- adjust `fontScale` default in `appConfig.ts` to 5

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d946cea8c832a87905d559dc9eba2