### PR TITLE
Fix typography scale

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -12,7 +12,9 @@ import { appConfig } from './src/config/appConfig';
 // --- Mount Application to the DOM ---
 const rootElement = document.getElementById('root');
 if (rootElement) {
-    document.documentElement.style.setProperty('--font-scale', String(appConfig.fontScale));
+    // Map the 1-10 font scale to a gentle CSS scaling factor.
+    const computedScale = 1 + (appConfig.fontScale - 3) * 0.1;
+    document.documentElement.style.setProperty('--font-scale', String(computedScale));
     const root = ReactDOM.createRoot(rootElement);
     root.render(
       <StrictMode>

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -25,7 +25,8 @@ interface AppConfig {
 
     /**
      * Global typography scale (1-10)
-     * Adjusts the root font size for accessibility testing.
+     * A value of 3 represents the default size. Values above or below
+     * 3 will adjust the base font size in small increments.
      */
     fontScale: number;
 
@@ -61,7 +62,7 @@ interface AppConfig {
 export const appConfig: AppConfig = {
     // --- GENERAL SETTINGS ---
     useStudioNav: false, // <-- SET TO false FOR PRODUCTION
-    fontScale: 5,
+    fontScale: 3,
 
     // --- PAGE THEMES ---
     pageThemes: {
@@ -82,5 +83,6 @@ export const appConfig: AppConfig = {
         showElearningShowcase: true,
         showGamificationSection: true,
         enableManifestoCoCreation: true,
-        useGamificationSidebar: true,
-        enableComponentLibrary: true,    }};
+        useGamificationSidebar: true,        enableComponentLibrary: true,
+    }
+};


### PR DESCRIPTION
## Summary
- correct default fontScale to 3 in appConfig
- scale fonts gently by mapping 1-10 values
- close config object cleanly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ea13fa610832aa332b303e017daa9